### PR TITLE
Add support for dynamic retrieval of type information from the server

### DIFF
--- a/include/opcua.hrl
+++ b/include/opcua.hrl
@@ -6,8 +6,10 @@
 -define(NID_NS(NS), #opcua_node_id{ns = NS}).
 -define(NNID(Num), #opcua_node_id{ns = 0, type = numeric, value = Num}).
 -define(NNID(NS, Num), #opcua_node_id{ns = NS, type = numeric, value = Num}).
--define(XID(NID), #opcua_expanded_node_id{node_id = NID}).
--define(XID(IDX, NID), #opcua_expanded_node_id{server_index = IDX, node_id = NID}).
+-define(XID(NID), #opcua_expanded_node_id{node_id = NID,
+    namespace_uri = undefined, server_index = undefined}).
+-define(XID(IDX, NID), #opcua_expanded_node_id{node_id = NID,
+    namespace_uri = undefined, server_index = IDX}).
 
 -define(UNDEF_NODE_ID, #opcua_node_id{ns = 0, type = numeric, value = 0}).
 -define(UNDEF_QUALIFIED_NAME, #opcua_qualified_name{ns = 0, name = undefined}).
@@ -86,7 +88,12 @@
 }).
 
 -record(opcua_error, {
-    status                      :: opcua:status()
+    status                      :: opcua:status(),
+    % This is only added by the client during decoding to simplify
+    % error handling, to give a hint of what node was involved in the error
+    % without having the API user keep track of what it requested when the
+    % the client actually knows this information.
+    node_id                     :: undefined | opcua:node_id()
 }).
 
 

--- a/src/opcua_codec_context.erl
+++ b/src/opcua_codec_context.erl
@@ -38,6 +38,7 @@
 -export([format_path/1]).
 -export([issue/2]).
 -export([issue_schema_not_found/2]).
+-export([issue_descriptor_not_found/2]).
 -export([issue_encoding_not_supported/2]).
 
 
@@ -128,6 +129,10 @@ issue(Ctx, Reason) ->
 -spec issue_schema_not_found(ctx(), term()) -> no_return().
 issue_schema_not_found(Ctx, NodeId) ->
     throw_issue(Ctx, schema_not_found, NodeId).
+
+-spec issue_descriptor_not_found(ctx(), term()) -> no_return().
+issue_descriptor_not_found(Ctx, NodeId) ->
+    throw_issue(Ctx, descriptor_not_found, NodeId).
 
 -spec issue_encoding_not_supported(ctx(), term()) -> no_return().
 issue_encoding_not_supported(Ctx, Details) ->

--- a/src/opcua_node.erl
+++ b/src/opcua_node.erl
@@ -52,7 +52,8 @@ id({NS, Name}) when is_integer(NS), is_atom(Name), NS >= 0 ->
 id({NS, Name}) when is_integer(NS), is_binary(Name), NS >= 0 ->
     #opcua_node_id{type = string, ns = NS, value = Name}.
 
--spec spec(opcua:node_id() | opcua:node_ref()) -> opcua:node_spec().
+-spec spec(opcua:node_id() | opcua:node_ref() | opcua:expanded_node_id()) ->
+    opcua:node_spec().
 spec(undefined) -> undefined;
 spec(?UNDEF_NODE_ID) -> undefined;
 spec(#opcua_node{node_id = NodeId}) -> spec(NodeId);
@@ -85,7 +86,7 @@ spec(#opcua_node_id{ns = 0, type = string, value = Id})
 % String with explicit namespace
 spec(#opcua_node_id{ns = NS, type = numeric, value = Id})
   when is_integer(NS), is_binary(Id) -> {NS, Id};
-% OTherwise, the node id itself...
+% Otherwise, the node id itself...
 spec(#opcua_node_id{} = NodeId) ->
   NodeId.
 

--- a/src/opcua_server_uacp.erl
+++ b/src/opcua_server_uacp.erl
@@ -78,9 +78,9 @@ handle_issues(State, Conn, [Issue | _Rest], _Acc) ->
         %     handle_issues(State2, Conn2, Rest, [Msg | Acc])
     end.
 
-handle_issue(State, _Conn, {schema_not_found, _PartialMsg, Schemas, _Cont}) ->
-    ?LOG_WARNING("Failed to handle request, schema(s) ~s not found",
-                 [opcua_node:format(Schemas)]),
+handle_issue(State, _Conn, {missing_typedata, _PartialMsg, TypeIds, _Cont}) ->
+    ?LOG_WARNING("Failed to handle request, missing type information nodes ~s",
+                 [opcua_node:format(TypeIds)]),
     {error, bad_data_type_id_unknown, State}.
 
 handle_requests(State, Conn, []) -> {ok, Conn, State};


### PR DESCRIPTION
 * The Open62541 custom data type example is failing because getting the custom variable value, it returns an extension object with a type encoding descriptor that do not point to any node. I have no idea what the client should be doing in this case, even though Prosys Browser seems to work just fine...
 * Added a way to make the client cache the retrieved node in its space. could be used to manually add data type information.