### PR TITLE
Fix decoding of heterogeneus arrays

### DIFF
--- a/src/opcua_nodeset_parser.erl
+++ b/src/opcua_nodeset_parser.erl
@@ -415,7 +415,10 @@ finalize_fields(Fields) ->
             true -> [0 || _ <- lists:seq(1, ValueRank)];
             false -> []
         end,
-        DataType = maps:get(data_type, F, undefined),
+        % NOTE:
+        % We do not allow undefined types in Fields and default to Variant.
+        % Which by specification is the Encoding type for the BaseDataType.
+        DataType = maps:get(data_type, F, variant),
         Field = #{
             name => Name,
             description => #opcua_localized_text{text = Desc},


### PR DESCRIPTION
When performing method calls, InputArguments is an array of eterogeneus elements.
~~In this case and in the case these are builtin, the type-id is encoded before each element.~~
Second approach is to insert variant as default type for structure fields at the parsing step.